### PR TITLE
Clone the profile's release.yml file if missing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,14 @@ runs:
         with:
           fetch-depth: 0
 
+      - name: Checkout profile
+        uses: actions/checkout@v4
+        if: ${{ hashFiles('.github/release.yml') != '' }}
+        with:
+          repository: "${{ github.repository_owner }}/.github"
+          sparse-checkout: .github/release.yml
+          sparse-checkout-cone-mode: false
+
       - name: Create Release Page
         shell: bash
         env:


### PR DESCRIPTION
If the .github/release.yml file is missing then this clones it from the profile repository. This allows setting an organization wide default without having to include the config in every repository.

Currently completely untested. Ideally it should also deal with the file not being present in the profile. Testing matrix:

|               | missing in profile | present in profile |
| ---- | ----- | ---- |
| present in repo |                    |                    |
| missing in repo |                    |                    |